### PR TITLE
Upper case connect http method

### DIFF
--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -26,7 +26,7 @@ impl ProxyConfig {
     /// return request string
     pub fn req_str(&self, target: &str) -> String {
         let mut builder = http::request::Builder::new()
-            .method("connect")
+            .method("CONNECT")
             .uri(target)
             .header("host", target);
         if self.keep_alive {


### PR DESCRIPTION
Convert connect http method in upper case to comply with CISCO WSA and perhaps some other commercial proxys